### PR TITLE
fix: added "JKI State Machine" package as dependency package in Drona.vipb

### DIFF
--- a/BuildSpec/Drona.vipb
+++ b/BuildSpec/Drona.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2022-05-31 18:14:50" Modified_Date="2023-07-25 19:17:58" Creator="sudarshan.rajkumar" Comments="" ID="f3b710f6dade19cb10a98fe5c0f7d4ab">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2022-05-31 18:14:50" Modified_Date="2023-07-25 19:40:42" Creator="sudarshan.rajkumar" Comments="" ID="b841e75f0df6d6285f5bd82ae713c08f">
   <Library_General_Settings>
     <Package_File_Name>Soliton_Technologies_lib_SLL_Drona</Package_File_Name>
     <Library_Version>0.2.1.3</Library_Version>
@@ -18,6 +18,7 @@
   <Advanced_Settings>
     <Package_Dependencies>
       <Additional_External_Dependencies>jki_lib_caraya &gt;=1.2.1.131</Additional_External_Dependencies>
+      <Additional_External_Dependencies>jki_lib_state_machine &gt;=2018.0.7.45</Additional_External_Dependencies>
       <Additional_External_Dependencies>oglib_variantconfig &gt;=4.0.0.5</Additional_External_Dependencies>
       <Additional_External_Dependencies>soliton_technologies_lib_sll_toolkit &gt;=1.0.0.1</Additional_External_Dependencies>
     </Package_Dependencies>
@@ -36,9 +37,9 @@
       <Copyright/>
       <Packager>Soliton Technologies</Packager>
       <URL/>
-      <Release_Notes>v0.2.1.1
+      <Release_Notes>v0.2.1
 
-- Added the bin3 files to list Drona Examples in LV example finder</Release_Notes>
+- Added JKI State Machine Package as dependency for SLL Drona</Release_Notes>
     </Description>
     <Destinations>
       <Toolkit_VIs>
@@ -354,7 +355,7 @@
         <Path>..\Source\APIs\DefineTest.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>81B66C8C321F8F137B289B4B94982347</GUID>
+      <GUID>0B7DFE88308ACC7A4475E43ADB19D902</GUID>
     </Functions_Palette_Data>
   </Library_Palette_Definition>
 </VI_Package_Builder_Settings>


### PR DESCRIPTION
Listed dependency Packages to install:

![Dependency](https://github.com/solitontech/SLL-Drona/assets/135618969/fc8a2727-59b1-409e-83e2-eade74bbee4e)

List of auto-dependency packages:

![List of dependency](https://github.com/solitontech/SLL-Drona/assets/135618969/0cd8b43a-f764-403b-b22d-f12841281949)

License agreements:

![License agreements](https://github.com/solitontech/SLL-Drona/assets/135618969/1a1a0efb-1ba9-41c0-9e00-5dc15b84b971)

Final Installed Packages:

![Installed Packages](https://github.com/solitontech/SLL-Drona/assets/135618969/8e9a6527-8959-417a-a025-b0c7388ab88f)


