### PR TITLE
Updated the Drona build spec package number for the v0.4.0 release

### DIFF
--- a/BuildSpec/Drona.vipb
+++ b/BuildSpec/Drona.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2022-05-31 18:14:50" Modified_Date="2023-08-14 11:47:54" Creator="sudarshan.rajkumar" Comments="" ID="586afd76cca97c9c407bec046e4fd886">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2022-05-31 18:14:50" Modified_Date="2023-08-14 12:43:51" Creator="sudarshan.rajkumar" Comments="" ID="daaf5668dc850b362f6dcd3f4bf37761">
   <Library_General_Settings>
     <Package_File_Name>Soliton_Technologies_lib_SLL_Drona</Package_File_Name>
-    <Library_Version>0.3.1.5</Library_Version>
+    <Library_Version>0.4.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\Source</Library_Source_Folder>
     <Library_Output_Folder>..\Build</Library_Output_Folder>
@@ -37,7 +37,7 @@
       <Copyright/>
       <Packager>Soliton Technologies</Packager>
       <URL/>
-      <Release_Notes>v0.3.1
+      <Release_Notes>v0.4.0
 
 - Added Drona quick start template into Drona Palette.</Release_Notes>
     </Description>
@@ -369,7 +369,7 @@
         <Path>..\Source\APIs\QuickStartTemplate.vi</Path>
         <VI_Title/>
       </Items_Data>
-      <GUID>A1741B63C35BC4EDA309A5E16C6EAEB6</GUID>
+      <GUID>51B9A3A34B4A28CCF06C9A0DC5F34DEA</GUID>
     </Functions_Palette_Data>
   </Library_Palette_Definition>
 </VI_Package_Builder_Settings>


### PR DESCRIPTION
Updated the Drona build spec package number as v0.4.0

All test cases passed. Ready for the v0.4.0 release!

![image](https://github.com/solitontech/SLL-Drona/assets/135618969/676542e3-4eff-4c02-a675-35e6495ef18f)
